### PR TITLE
Add BitPreço (Brazil)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -316,6 +316,8 @@ id: exchanges
       <div>
         <h3 id="brazil" class="no_toc">Brazil</h3>
         <p>
+          <a class="marketplace-link" href="https:/https://bitpreco.com/">BitPreço</a>
+          <br>
           <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
           <br>
           <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>


### PR DESCRIPTION
Please add BitPreço Exchange in Brazil Exchanges

It's already listed at many other sites like 

https://www.cointradermonitor.com/preco-bitcoin-brasil
https://biscoint.io/buy/btc/brl?amount=1000&isQuote=true

and so on.

Thank you in advance